### PR TITLE
ReplacementPart fsm init

### DIFF
--- a/Source code/MscModApi/MscPartApi.cs
+++ b/Source code/MscModApi/MscPartApi.cs
@@ -15,7 +15,7 @@ namespace MscModApi
 		public override string ID => "MscModApi";
 		public override string Name => "MscModApi";
 		public override string Author => "DonnerPlays";
-		public override string Version => "1.0.3";
+		public override string Version => "1.0.4";
 		
 		public override string Description =>
 			"This allows developers to make their parts installable on the car. Also adds screws";

--- a/Source code/MscModApi/MscPartApi.cs
+++ b/Source code/MscModApi/MscPartApi.cs
@@ -16,7 +16,7 @@ namespace MscModApi
 		public override string Name => "MscModApi";
 		public override string Author => "DonnerPlays";
 		public override string Version => "1.0.3";
-
+		
 		public override string Description =>
 			"This allows developers to make their parts installable on the car. Also adds screws";
 

--- a/Source code/MscModApi/MscPartApi.cs
+++ b/Source code/MscModApi/MscPartApi.cs
@@ -86,6 +86,7 @@ namespace MscModApi
 
 		private void Load()
 		{
+			ModConsole.Print($"<color=white>You are running <color=blue>{Name}</color> [<color=green>v{Version}</color>]</color>");
 			Logger.InitLogger(this);
 			tool = new Tool();
 			Shop.Init();

--- a/Source code/MscModApi/Parts/ReplacePart/OldPart.cs
+++ b/Source code/MscModApi/Parts/ReplacePart/OldPart.cs
@@ -2,6 +2,7 @@
 using HutongGames.PlayMaker;
 using MSCLoader;
 using System.Linq;
+using MSCLoader.Helper;
 using MscModApi.Tools;
 using UnityEngine;
 
@@ -32,6 +33,16 @@ namespace MscModApi.Parts.ReplacePart
 
 			assembleFsm = GetFsmByName(trigger, "Assembly");
 			removalFsm = GetFsmByName(gameObject, "Removal");
+
+			if (!assembleFsm.Fsm.Initialized)
+			{
+				assembleFsm.InitializeFSM();
+			}
+
+			if (!removalFsm.Fsm.Initialized)
+			{
+				removalFsm.InitializeFSM();
+			}
 		}
 
 		private static PlayMakerFSM GetFsmByName(GameObject gameObject, string fsmName)


### PR DESCRIPTION
This fixes an issue when parts are used that can be bought and are not yet bought (like Racing Carburetor)
That would prevent it from loading as the FSM is not yet initialized.

Also adds a message on game load showing the api version in the ModConsole